### PR TITLE
feat: Add max message size configuration for gRPC channel

### DIFF
--- a/PasarGuardNodeBridge/__init__.py
+++ b/PasarGuardNodeBridge/__init__.py
@@ -59,6 +59,9 @@ def create_node(
             - logger (logging.Logger): Custom logger instance. If None, a default logger is created.
             - default_timeout (int): Default timeout in seconds for public API methods. Defaults to 10.
             - internal_timeout (int): Default timeout in seconds for internal operations. Defaults to 15.
+            - max_message_size (int): Maximum gRPC message size in bytes. Defaults to 10MB.
+                                     Can also be set via GRPC_MAX_MESSAGE_SIZE environment variable.
+                                     Set to 0 to use grpclib default (4MB).
 
     Returns:
         PasarGuardNode: An initialized node instance ready for API operations.


### PR DESCRIPTION
- Introduced max_message_size parameter in Node class to allow customization of gRPC message size.
- Default message size is set to 10MB, configurable via GRPC_MAX_MESSAGE_SIZE environment variable.
- Updated channel initialization to handle large node configurations and ensure compatibility with various use cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable maximum message size limits in gRPC communication. The default limit is 10MB, which can be adjusted during initialization or through environment-based configuration. Setting it to 0 uses the library's default (4MB).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->