### PR TITLE
Preserve lifecycle lease when node stop fails

### DIFF
--- a/PasarGuardNodeBridge/controller.py
+++ b/PasarGuardNodeBridge/controller.py
@@ -339,10 +339,7 @@ class Controller:
         node_version: str = "",
         core_version: str = "",
     ) -> None:
-        heartbeat = self._lifecycle_heartbeat_tasks.pop(lease.token, None)
-        if heartbeat is not None:
-            heartbeat.cancel()
-            await heartbeat
+        await self._stop_lifecycle_heartbeat(lease)
 
         if observed is None:
             await self._lifecycle_coordinator.release(lease)
@@ -358,6 +355,15 @@ class Controller:
             core_version=core_version,
         )
         await self._lifecycle_coordinator.release(lease, state)
+
+    async def _stop_lifecycle_heartbeat(self, lease: LifecycleLease) -> None:
+        heartbeat = self._lifecycle_heartbeat_tasks.pop(lease.token, None)
+        if heartbeat is not None:
+            heartbeat.cancel()
+            try:
+                await heartbeat
+            except asyncio.CancelledError:
+                pass
 
     async def get_lifecycle_state(self) -> NodeLifecycleState | None:
         return await self._lifecycle_coordinator.get_state(self.node_id)

--- a/PasarGuardNodeBridge/controller.py
+++ b/PasarGuardNodeBridge/controller.py
@@ -364,6 +364,8 @@ class Controller:
                 await heartbeat
             except asyncio.CancelledError:
                 pass
+            except Exception:
+                self.logger.exception("[%s] Lifecycle heartbeat failed during cleanup", self.name)
 
     async def get_lifecycle_state(self) -> NodeLifecycleState | None:
         return await self._lifecycle_coordinator.get_state(self.node_id)

--- a/PasarGuardNodeBridge/grpclib.py
+++ b/PasarGuardNodeBridge/grpclib.py
@@ -200,19 +200,14 @@ class Node(PasarGuardNode):
                 async with self._node_lock:
                     await self.disconnect()
 
-                    try:
-                        await self._handle_grpc_request(
-                            method=self._client.Stop,
-                            request=service.Empty(),
-                            timeout=timeout,
-                        )
-                    except Exception:
-                        pass
-                    await self._release_lifecycle_lease(
-                        lease, LifecycleStatus.STOPPED, desired=LifecycleStatus.STOPPED
+                    await self._handle_grpc_request(
+                        method=self._client.Stop,
+                        request=service.Empty(),
+                        timeout=timeout,
                     )
+                    await self._release_lifecycle_lease(lease, LifecycleStatus.STOPPED, desired=LifecycleStatus.STOPPED)
             except BaseException:
-                await self._release_lifecycle_lease(lease, LifecycleStatus.BROKEN, desired=LifecycleStatus.STOPPED)
+                await self._stop_lifecycle_heartbeat(lease)
                 raise
         finally:
             await self._json_client.close()

--- a/PasarGuardNodeBridge/grpclib.py
+++ b/PasarGuardNodeBridge/grpclib.py
@@ -198,13 +198,12 @@ class Node(PasarGuardNode):
             lease = await self._acquire_lifecycle_lease(LifecycleOperation.STOP)
             try:
                 async with self._node_lock:
-                    await self.disconnect()
-
                     await self._handle_grpc_request(
                         method=self._client.Stop,
                         request=service.Empty(),
                         timeout=timeout,
                     )
+                    await self.disconnect()
                     await self._release_lifecycle_lease(lease, LifecycleStatus.STOPPED, desired=LifecycleStatus.STOPPED)
             except BaseException:
                 await self._stop_lifecycle_heartbeat(lease)

--- a/PasarGuardNodeBridge/rest.py
+++ b/PasarGuardNodeBridge/rest.py
@@ -224,15 +224,10 @@ class Node(PasarGuardNode):
                 async with self._node_lock:
                     await self.disconnect()
 
-                    try:
-                        await self._make_request(method="PUT", endpoint="stop", timeout=timeout)
-                    except Exception:
-                        pass
-                    await self._release_lifecycle_lease(
-                        lease, LifecycleStatus.STOPPED, desired=LifecycleStatus.STOPPED
-                    )
+                    await self._make_request(method="PUT", endpoint="stop", timeout=timeout)
+                    await self._release_lifecycle_lease(lease, LifecycleStatus.STOPPED, desired=LifecycleStatus.STOPPED)
             except BaseException:
-                await self._release_lifecycle_lease(lease, LifecycleStatus.BROKEN, desired=LifecycleStatus.STOPPED)
+                await self._stop_lifecycle_heartbeat(lease)
                 raise
         finally:
             await self._client.close()

--- a/PasarGuardNodeBridge/rest.py
+++ b/PasarGuardNodeBridge/rest.py
@@ -222,9 +222,8 @@ class Node(PasarGuardNode):
             lease = await self._acquire_lifecycle_lease(LifecycleOperation.STOP)
             try:
                 async with self._node_lock:
-                    await self.disconnect()
-
                     await self._make_request(method="PUT", endpoint="stop", timeout=timeout)
+                    await self.disconnect()
                     await self._release_lifecycle_lease(lease, LifecycleStatus.STOPPED, desired=LifecycleStatus.STOPPED)
             except BaseException:
                 await self._stop_lifecycle_heartbeat(lease)

--- a/tests/test_stop_lifecycle.py
+++ b/tests/test_stop_lifecycle.py
@@ -74,14 +74,26 @@ class StopLifecycleTests(unittest.IsolatedAsyncioTestCase):
         coordinator = InMemoryNodeLifecycleCoordinator()
         node = RestNode.__new__(RestNode)
         self._configure_node(node, coordinator)
+        node._client = SimpleNamespace(close=AsyncMock())
+        node._make_request = AsyncMock(side_effect=NodeAPIError(503, "REST stop failed"))
+
+        async def heartbeat_that_fails_during_cleanup():
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError as exc:
+                raise RuntimeError("heartbeat failed") from exc
+
         lease = await coordinator.try_acquire(node.node_id, node.worker_id, LifecycleOperation.STOP, 30)
         self.assertIsNotNone(lease)
-        heartbeat = asyncio.get_running_loop().create_future()
-        heartbeat.set_exception(RuntimeError("heartbeat failed"))
-        node._lifecycle_heartbeat_tasks[lease.token] = heartbeat
+        node._acquire_lifecycle_lease = AsyncMock(return_value=lease)
+        node._lifecycle_heartbeat_tasks[lease.token] = asyncio.create_task(heartbeat_that_fails_during_cleanup())
+        await asyncio.sleep(0)
 
-        await node._stop_lifecycle_heartbeat(lease)
+        with self.assertRaises(NodeAPIError) as error:
+            await node.stop()
 
+        self.assertEqual(error.exception.code, 503)
+        self.assertEqual(error.exception.detail, "REST stop failed")
         node.logger.exception.assert_called_once()
 
 

--- a/tests/test_stop_lifecycle.py
+++ b/tests/test_stop_lifecycle.py
@@ -1,0 +1,72 @@
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from PasarGuardNodeBridge.controller import Health, NodeAPIError
+from PasarGuardNodeBridge.grpclib import Node as GrpcNode
+from PasarGuardNodeBridge.rest import Node as RestNode
+from PasarGuardNodeBridge.storage import InMemoryNodeLifecycleCoordinator, LifecycleOperation, LifecycleStatus
+
+
+class StopLifecycleTests(unittest.IsolatedAsyncioTestCase):
+    def _configure_node(self, node, coordinator: InMemoryNodeLifecycleCoordinator) -> None:
+        node.node_id = "node-1"
+        node.worker_id = "worker-1"
+        node._default_timeout = 10
+        node._node_lock = asyncio.Lock()
+        node._lifecycle_coordinator = coordinator
+        node._lifecycle_lease_seconds = 30
+        node._lifecycle_heartbeat_tasks = {}
+        node.get_health = AsyncMock(return_value=Health.HEALTHY)
+        node.disconnect = AsyncMock()
+        node._json_client = SimpleNamespace(close=AsyncMock())
+
+    async def _assert_failed_stop_keeps_lease(self, node) -> None:
+        with self.assertRaises(NodeAPIError) as error:
+            await node.stop()
+
+        self.assertEqual(error.exception.code, 503)
+        state = await node._lifecycle_coordinator.get_state(node.node_id)
+        self.assertEqual(state.observed, LifecycleStatus.STOPPING)
+
+        competing_lease = await node._lifecycle_coordinator.try_acquire(
+            node.node_id,
+            "worker-2",
+            LifecycleOperation.START,
+            30,
+        )
+        self.assertIsNone(competing_lease)
+        self.assertEqual(node._lifecycle_heartbeat_tasks, {})
+
+    async def test_rest_stop_propagates_error_without_releasing_lease(self):
+        coordinator = InMemoryNodeLifecycleCoordinator()
+        node = RestNode.__new__(RestNode)
+        self._configure_node(node, coordinator)
+        node._client = SimpleNamespace(close=AsyncMock())
+        node._make_request = AsyncMock(side_effect=NodeAPIError(503, "REST stop failed"))
+
+        await self._assert_failed_stop_keeps_lease(node)
+
+        node._make_request.assert_awaited_once_with(method="PUT", endpoint="stop", timeout=10)
+        node._client.close.assert_awaited_once()
+        node._json_client.close.assert_awaited_once()
+
+    async def test_grpc_stop_propagates_error_without_releasing_lease(self):
+        coordinator = InMemoryNodeLifecycleCoordinator()
+        node = GrpcNode.__new__(GrpcNode)
+        self._configure_node(node, coordinator)
+        node._client = SimpleNamespace(Stop=AsyncMock())
+        node._handle_grpc_request = AsyncMock(side_effect=NodeAPIError(503, "gRPC stop failed"))
+
+        await self._assert_failed_stop_keeps_lease(node)
+
+        node._handle_grpc_request.assert_awaited_once()
+        request = node._handle_grpc_request.await_args.kwargs
+        self.assertIs(request["method"], node._client.Stop)
+        self.assertEqual(request["timeout"], 10)
+        node._json_client.close.assert_awaited_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stop_lifecycle.py
+++ b/tests/test_stop_lifecycle.py
@@ -1,7 +1,7 @@
 import asyncio
 import unittest
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 from PasarGuardNodeBridge.controller import Health, NodeAPIError
 from PasarGuardNodeBridge.grpclib import Node as GrpcNode
@@ -12,12 +12,14 @@ from PasarGuardNodeBridge.storage import InMemoryNodeLifecycleCoordinator, Lifec
 class StopLifecycleTests(unittest.IsolatedAsyncioTestCase):
     def _configure_node(self, node, coordinator: InMemoryNodeLifecycleCoordinator) -> None:
         node.node_id = "node-1"
+        node.name = "node-1"
         node.worker_id = "worker-1"
         node._default_timeout = 10
         node._node_lock = asyncio.Lock()
         node._lifecycle_coordinator = coordinator
         node._lifecycle_lease_seconds = 30
         node._lifecycle_heartbeat_tasks = {}
+        node.logger = Mock()
         node.get_health = AsyncMock(return_value=Health.HEALTHY)
         node.disconnect = AsyncMock()
         node._json_client = SimpleNamespace(close=AsyncMock())
@@ -38,6 +40,7 @@ class StopLifecycleTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertIsNone(competing_lease)
         self.assertEqual(node._lifecycle_heartbeat_tasks, {})
+        node.disconnect.assert_not_awaited()
 
     async def test_rest_stop_propagates_error_without_releasing_lease(self):
         coordinator = InMemoryNodeLifecycleCoordinator()
@@ -66,6 +69,20 @@ class StopLifecycleTests(unittest.IsolatedAsyncioTestCase):
         self.assertIs(request["method"], node._client.Stop)
         self.assertEqual(request["timeout"], 10)
         node._json_client.close.assert_awaited_once()
+
+    async def test_failed_heartbeat_does_not_mask_stop_error(self):
+        coordinator = InMemoryNodeLifecycleCoordinator()
+        node = RestNode.__new__(RestNode)
+        self._configure_node(node, coordinator)
+        lease = await coordinator.try_acquire(node.node_id, node.worker_id, LifecycleOperation.STOP, 30)
+        self.assertIsNotNone(lease)
+        heartbeat = asyncio.get_running_loop().create_future()
+        heartbeat.set_exception(RuntimeError("heartbeat failed"))
+        node._lifecycle_heartbeat_tasks[lease.token] = heartbeat
+
+        await node._stop_lifecycle_heartbeat(lease)
+
+        node.logger.exception.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- propagate REST/gRPC stop failures without marking the local node disconnected first, so the operation remains retryable
- keep the lifecycle lease until it expires after an ambiguous failure
- prevent a failed/cancelled lifecycle heartbeat from masking the original stop error

## Validation

- `.venv\\Scripts\\python.exe -m unittest discover -s tests -v` — 14 passed
- focused Ruff check/format and `git diff --check`

The repository-wide Ruff-format check reports pre-existing README alignment outside this PR; the changed Python/test files are formatted.