### PR TITLE
fix: accept api_port in create_node factory

### DIFF
--- a/PasarGuardNodeBridge/__init__.py
+++ b/PasarGuardNodeBridge/__init__.py
@@ -53,6 +53,7 @@ def create_node(
     port: int,
     server_ca: str,
     api_key: str,
+    api_port: int,
     **kwargs,
 ) -> PasarGuardNode:
     """
@@ -67,6 +68,8 @@ def create_node(
         port (int): Port number used to connect to the node.
         server_ca (str): The server's SSL certificate as a string (PEM format).
         api_key (str): API key used for authentication with the node.
+        api_port (int): Port serving the node's JSON service API. For `NodeType.grpc` this is a
+            separate port from `port`, which carries gRPC traffic only.
         **kwargs: Additional optional arguments:
             - name (str): Node instance name for logging. Defaults to "default".
             - extra (dict): Optional dictionary to pass custom metadata or configuration. Defaults to {}.
@@ -75,6 +78,7 @@ def create_node(
             - internal_timeout (int): Default timeout in seconds for internal operations. Defaults to 15.
             - proxy (str): Optional upstream proxy URL. Supports socks4, socks4a, socks5, socks5h,
               http, and https URL forms with or without credentials.
+            - max_message_size (int): Maximum gRPC message size in bytes. `NodeType.grpc` only.
 
     Returns:
         PasarGuardNode: An initialized node instance ready for API operations.
@@ -89,6 +93,7 @@ def create_node(
         ...     connection=NodeType.grpc,
         ...     address="172.27.158.135",
         ...     port=2096,
+        ...     api_port=2097,
         ...     server_ca=server_ca_content,
         ...     api_key=api_key,
         ... )
@@ -98,6 +103,7 @@ def create_node(
         ...     connection=NodeType.grpc,
         ...     address="172.27.158.135",
         ...     port=2096,
+        ...     api_port=2097,
         ...     server_ca=server_ca_content,
         ...     api_key=api_key,
         ...     default_timeout=30,
@@ -116,6 +122,7 @@ def create_node(
         return GrpcNode(
             address=address,
             port=port,
+            api_port=api_port,
             server_ca=server_ca,
             api_key=api_key,
             **kwargs,
@@ -125,6 +132,7 @@ def create_node(
         return RestNode(
             address=address,
             port=port,
+            api_port=api_port,
             server_ca=server_ca,
             api_key=api_key,
             **kwargs,

--- a/PasarGuardNodeBridge/__init__.py
+++ b/PasarGuardNodeBridge/__init__.py
@@ -54,6 +54,7 @@ def create_node(
     server_ca: str,
     api_key: str,
     api_port: int,
+    max_message_size: int | None = None,
     **kwargs,
 ) -> PasarGuardNode:
     """
@@ -125,6 +126,7 @@ def create_node(
             api_port=api_port,
             server_ca=server_ca,
             api_key=api_key,
+            max_message_size=max_message_size,
             **kwargs,
         )
 

--- a/tests/test_create_node_signature.py
+++ b/tests/test_create_node_signature.py
@@ -1,5 +1,6 @@
 import inspect
 import unittest
+from unittest.mock import patch
 
 from PasarGuardNodeBridge import NodeAPIError, NodeType, create_node
 from PasarGuardNodeBridge import grpclib as grpclib_backend
@@ -58,6 +59,43 @@ class CreateNodeSignatureTest(unittest.TestCase):
         self.assertTrue(
             accepts_kwargs or not unsupported,
             f"NodeConfig fields not accepted by create_node(): {sorted(unsupported)}",
+        )
+
+    def test_grpc_forwards_distinct_service_port_and_message_limit(self):
+        with patch("PasarGuardNodeBridge.GrpcNode") as grpc_node:
+            create_node(
+                connection=NodeType.grpc,
+                **DOCUMENTED_CALL,
+                max_message_size=8 * 1024 * 1024,
+                name="test-grpc",
+            )
+
+        grpc_node.assert_called_once_with(
+            address="127.0.0.1",
+            port=2096,
+            api_port=2097,
+            server_ca=DOCUMENTED_CALL["server_ca"],
+            api_key=DOCUMENTED_CALL["api_key"],
+            max_message_size=8 * 1024 * 1024,
+            name="test-grpc",
+        )
+
+    def test_rest_does_not_receive_grpc_message_limit(self):
+        with patch("PasarGuardNodeBridge.RestNode") as rest_node:
+            create_node(
+                connection=NodeType.rest,
+                **DOCUMENTED_CALL,
+                max_message_size=8 * 1024 * 1024,
+                name="test-rest",
+            )
+
+        rest_node.assert_called_once_with(
+            address="127.0.0.1",
+            port=2096,
+            api_port=2097,
+            server_ca=DOCUMENTED_CALL["server_ca"],
+            api_key=DOCUMENTED_CALL["api_key"],
+            name="test-rest",
         )
 
 

--- a/tests/test_create_node_signature.py
+++ b/tests/test_create_node_signature.py
@@ -1,0 +1,65 @@
+import inspect
+import unittest
+
+from PasarGuardNodeBridge import NodeAPIError, NodeType, create_node
+from PasarGuardNodeBridge import grpclib as grpclib_backend
+from PasarGuardNodeBridge import rest as rest_backend
+from PasarGuardNodeBridge.storage import NodeConfig
+
+DOCUMENTED_CALL = {
+    "address": "127.0.0.1",
+    "port": 2096,
+    "api_port": 2097,
+    "server_ca": "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n",
+    "api_key": "6f9619ff-8b86-d011-b42d-00c04fc964ff",
+}
+
+
+def _required_params(func) -> set[str]:
+    return {
+        name
+        for name, param in inspect.signature(func).parameters.items()
+        if name != "self"
+        and param.default is inspect.Parameter.empty
+        and param.kind in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+    }
+
+
+class CreateNodeSignatureTest(unittest.TestCase):
+    """`create_node` must accept every argument its backends require.
+
+    Regression guard: `api_port` is required by both `rest.Node` and `grpclib.Node`, but was
+    missing from the factory signature, so the call form shown in the README and in this
+    function's own docstring raised
+    `TypeError: Node.__init__() missing 1 required positional argument: 'api_port'`.
+    """
+
+    def test_factory_accepts_every_required_backend_argument(self):
+        factory_params = _required_params(create_node) | {"kwargs"}
+        for backend in (rest_backend.Node, grpclib_backend.Node):
+            with self.subTest(backend=backend.__module__):
+                missing = _required_params(backend.__init__) - factory_params
+                self.assertEqual(missing, set(), f"create_node() cannot supply {sorted(missing)}")
+
+    def test_documented_call_form_binds_without_type_error(self):
+        # A real node is not constructed here: that needs a valid PEM chain and a reachable
+        # host. Failing at TLS setup proves argument binding already succeeded, whereas the
+        # regression being guarded raised TypeError before any connection work started.
+        for connection in (NodeType.rest, NodeType.grpc):
+            with self.subTest(connection=connection), self.assertRaises(NodeAPIError):
+                create_node(connection=connection, **DOCUMENTED_CALL)
+
+    def test_every_node_config_field_is_accepted(self):
+        signature = inspect.signature(create_node)
+        accepts_kwargs = any(p.kind is inspect.Parameter.VAR_KEYWORD for p in signature.parameters.values())
+        # `connection` is supplied separately by create_node_from_config.
+        fields = set(NodeConfig.__dataclass_fields__) - {"connection"}
+        unsupported = fields - set(signature.parameters)
+        self.assertTrue(
+            accepts_kwargs or not unsupported,
+            f"NodeConfig fields not accepted by create_node(): {sorted(unsupported)}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`create_node()` documented an `api_port`, and both backends require it, but the factory only accepted it indirectly through `**kwargs`. This made the public signature misleading and allowed callers to omit a port that is distinct from the gRPC listener.

## Changes

- Make `api_port` an explicit required factory argument and forward it to REST and gRPC nodes.
- Keep `port` and `api_port` independent; no fallback is introduced.
- Accept `max_message_size` explicitly, forward it only to the gRPC constructor, and prevent `NodeConfig` from leaking this gRPC-only option into the REST constructor.
- Add focused constructor-forwarding tests using `port=2096`, `api_port=2097`, and a non-default message limit.

## Validation

- `python -m pytest -q` — 16 passed, 4 subtests passed.
- `python -m ruff check PasarGuardNodeBridge tests` — passed.
- Synthetic Git merge with #18 — clean; both merge orders resolve to the same merged tree.
- `git diff --check` — passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Node creation now supports configuring a separate API port for REST and gRPC connections.
  * Added an optional gRPC message-size limit setting.

* **Documentation**
  * Updated usage documentation and examples to include the required API port and optional message-size configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->